### PR TITLE
Several changes

### DIFF
--- a/stringscore.go
+++ b/stringscore.go
@@ -24,6 +24,10 @@ func Score(target string, query string) int {
 		return 0 // return early if target or query are undefined
 	}
 
+	if len(query) > len(target) {
+		return 0 // impossible for query to be a substring
+	}
+
 	targetLower := strings.ToLower(target)
 	queryLower := strings.ToLower(query)
 

--- a/stringscore.go
+++ b/stringscore.go
@@ -4,7 +4,6 @@ package stringscore
 
 import (
 	"strings"
-	"unicode"
 )
 
 var wordPathBoundary = [...]byte{'-', '_', ' ', '/', '\\', '.'}
@@ -70,7 +69,7 @@ func Score(target string, query string) int {
 			if afterSeparator {
 				// After separator bonus
 				score += 7
-			} else if unicode.IsUpper(rune(target[targetIdx])) {
+			} else if isUpperASCII(target[targetIdx]) {
 				// Inside word upper case bonus
 				score += 1
 			}
@@ -80,4 +79,8 @@ func Score(target string, query string) int {
 	}
 
 	return score
+}
+
+func isUpperASCII(c byte) bool {
+	return 65 <= c && c <= 90
 }

--- a/stringscore.go
+++ b/stringscore.go
@@ -55,20 +55,23 @@ func Score(target string, query string) int {
 		if targetIdx == 0 {
 			score += 8
 		} else {
-			// After separator bonus
+			afterSeparator := false
 			for _, w := range wordPathBoundary {
 				if w == target[targetIdx-1] {
-					score += 7
-					goto next
+					afterSeparator = true
+					break
 				}
 			}
-		}
-		if unicode.IsUpper(rune(target[targetIdx])) {
-			// Inside word upper case bonus
-			score += 1
+
+			if afterSeparator {
+				// After separator bonus
+				score += 7
+			} else if unicode.IsUpper(rune(target[targetIdx])) {
+				// Inside word upper case bonus
+				score += 1
+			}
 		}
 
-	next:
 		startAt = targetIdx + 1
 	}
 

--- a/stringscore.go
+++ b/stringscore.go
@@ -42,7 +42,7 @@ func Score(target string, query string) int {
 		}
 
 		// Character match bonus
-		score += 1
+		score++
 
 		// Consecutive match bonus
 		if startAt == targetIdx {
@@ -51,7 +51,7 @@ func Score(target string, query string) int {
 
 		// Same case bonus
 		if target[targetIdx] == query[queryIdx] {
-			score += 1
+			score++
 		}
 
 		// Start of word bonus
@@ -71,7 +71,7 @@ func Score(target string, query string) int {
 				score += 7
 			} else if isUpperASCII(target[targetIdx]) {
 				// Inside word upper case bonus
-				score += 1
+				score++
 			}
 		}
 

--- a/stringscore.go
+++ b/stringscore.go
@@ -30,7 +30,7 @@ func Score(target string, query string) int {
 	startAt := 0
 	score := 0
 
-	for queryIdx := range query {
+	for queryIdx := 0; queryIdx < len(query); queryIdx++ {
 		targetIdx := strings.IndexByte(targetLower[startAt:], queryLower[queryIdx]) + startAt
 
 		if targetIdx == -1 {

--- a/stringscore.go
+++ b/stringscore.go
@@ -28,12 +28,10 @@ func Score(target string, query string) int {
 	targetLower := strings.ToLower(target)
 	queryLower := strings.ToLower(query)
 
-	index := 0
 	startAt := 0
 	score := 0
 
-	for index < queryLen {
-
+	for index := range query {
 		indexOf := strings.IndexByte(targetLower[startAt:], queryLower[index]) + startAt
 
 		if indexOf == -1 {
@@ -73,7 +71,6 @@ func Score(target string, query string) int {
 
 	next:
 		startAt = indexOf + 1
-		index++
 	}
 
 	return score

--- a/stringscore.go
+++ b/stringscore.go
@@ -30,8 +30,8 @@ func Score(target string, query string) int {
 	startAt := 0
 	score := 0
 
-	for index := range query {
-		indexOf := strings.IndexByte(targetLower[startAt:], queryLower[index]) + startAt
+	for queryIdx := range query {
+		indexOf := strings.IndexByte(targetLower[startAt:], queryLower[queryIdx]) + startAt
 
 		if indexOf == -1 {
 			score = 0 // This makes sure that the query is contained in the target
@@ -47,7 +47,7 @@ func Score(target string, query string) int {
 		}
 
 		// Same case bonus
-		if target[indexOf] == query[index] {
+		if target[indexOf] == query[queryIdx] {
 			score += 1
 		}
 

--- a/stringscore.go
+++ b/stringscore.go
@@ -33,7 +33,7 @@ func Score(target string, query string) int {
 	for queryIdx := 0; queryIdx < len(query); queryIdx++ {
 		targetIdx := strings.IndexByte(targetLower[startAt:], queryLower[queryIdx]) + startAt
 
-		if targetIdx == -1 {
+		if targetIdx < startAt {
 			score = 0 // This makes sure that the query is contained in the target
 			break
 		}

--- a/stringscore.go
+++ b/stringscore.go
@@ -31,9 +31,9 @@ func Score(target string, query string) int {
 	score := 0
 
 	for queryIdx := range query {
-		indexOf := strings.IndexByte(targetLower[startAt:], queryLower[queryIdx]) + startAt
+		targetIdx := strings.IndexByte(targetLower[startAt:], queryLower[queryIdx]) + startAt
 
-		if indexOf == -1 {
+		if targetIdx == -1 {
 			score = 0 // This makes sure that the query is contained in the target
 			break
 		}
@@ -42,34 +42,34 @@ func Score(target string, query string) int {
 		score += 1
 
 		// Consecutive match bonus
-		if startAt == indexOf {
+		if startAt == targetIdx {
 			score += 5
 		}
 
 		// Same case bonus
-		if target[indexOf] == query[queryIdx] {
+		if target[targetIdx] == query[queryIdx] {
 			score += 1
 		}
 
 		// Start of word bonus
-		if indexOf == 0 {
+		if targetIdx == 0 {
 			score += 8
 		} else {
 			// After separator bonus
 			for _, w := range wordPathBoundary {
-				if w == target[indexOf-1] {
+				if w == target[targetIdx-1] {
 					score += 7
 					goto next
 				}
 			}
 		}
-		if unicode.IsUpper(rune(target[indexOf])) {
+		if unicode.IsUpper(rune(target[targetIdx])) {
 			// Inside word upper case bonus
 			score += 1
 		}
 
 	next:
-		startAt = indexOf + 1
+		startAt = targetIdx + 1
 	}
 
 	return score

--- a/stringscore.go
+++ b/stringscore.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-var wordPathBoundary = [...]byte{'-', '_', ' ', '/', '\\', '.'}
-
 // Score computes a score for the given string and the given query.
 //
 // Rules:
@@ -57,28 +55,24 @@ func Score(target string, query string) int {
 		// Start of word bonus
 		if targetIdx == 0 {
 			score += 8
-		} else {
-			afterSeparator := false
-			for _, w := range wordPathBoundary {
-				if w == target[targetIdx-1] {
-					afterSeparator = true
-					break
-				}
-			}
-
-			if afterSeparator {
-				// After separator bonus
-				score += 7
-			} else if isUpperASCII(target[targetIdx]) {
-				// Inside word upper case bonus
-				score++
-			}
+		} else if isWordSeparator(target[targetIdx-1]) {
+			// After separator bonus
+			score += 7
+		} else if isUpperASCII(target[targetIdx]) {
+			// Inside word upper case bonus
+			score++
 		}
 
 		startAt = targetIdx + 1
 	}
 
 	return score
+}
+
+const wordPathBoundary = "-_ /\\."
+
+func isWordSeparator(c byte) bool {
+	return strings.IndexByte(wordPathBoundary, c) >= 0
 }
 
 func isUpperASCII(c byte) bool {

--- a/stringscore.go
+++ b/stringscore.go
@@ -24,7 +24,6 @@ func Score(target string, query string) int {
 		return 0 // return early if target or query are undefined
 	}
 
-	queryLen := len(query)
 	targetLower := strings.ToLower(target)
 	queryLower := strings.ToLower(query)
 
@@ -48,7 +47,7 @@ func Score(target string, query string) int {
 		}
 
 		// Same case bonus
-		if indexOf < queryLen && target[indexOf] == query[indexOf] {
+		if target[indexOf] == query[index] {
 			score += 1
 		}
 

--- a/stringscore_test.go
+++ b/stringscore_test.go
@@ -8,20 +8,20 @@ import (
 )
 
 func TestScore(t *testing.T) {
-	target := "HelLo-World"
+	target := "HeLlo-World"
 
 	scores := make([]int, 0, 0)
 	scores = append(scores, stringscore.Score(target, "HelLo-World")) // direct case match
 	scores = append(scores, stringscore.Score(target, "hello-world")) // direct mix-case match
 	scores = append(scores, stringscore.Score(target, "HW"))          // direct case prefix (multiple)
-	scores = append(scores, stringscore.Score(target, "H"))           // direct case prefix
 	scores = append(scores, stringscore.Score(target, "hw"))          // direct mix-case prefix (multiple)
+	scores = append(scores, stringscore.Score(target, "H"))           // direct case prefix
 	scores = append(scores, stringscore.Score(target, "h"))           // direct mix-case prefix
 	scores = append(scores, stringscore.Score(target, "W"))           // direct case word prefix
 	scores = append(scores, stringscore.Score(target, "w"))           // direct mix-case word prefix
 	scores = append(scores, stringscore.Score(target, "Ld"))          // in-string case match (multiple)
-	scores = append(scores, stringscore.Score(target, "L"))           // in-string case match
 	scores = append(scores, stringscore.Score(target, "ld"))          // in-string mix-case match
+	scores = append(scores, stringscore.Score(target, "L"))           // in-string case match
 	scores = append(scores, stringscore.Score(target, "l"))           // in-string mix-case match
 	scores = append(scores, stringscore.Score(target, "4"))           // no match
 


### PR DESCRIPTION
Most of these commits are making this more idiomatic go. However, some are actual deviations from vscode's implementation:

* More understandable variable names.
* An extra early termination check
* A fix. I believe vscode has a out of bounds string access (which javascript probably just ignores as undefined). I noticed this thanks to the better variable names. https://github.com/Microsoft/vscode/pull/34576
* Changes to the test case. vscode's test case is broken. https://github.com/Microsoft/vscode/pull/34576

Notes:
* We should probably explicitly mark that this implementation does the wrong thing for unicode (ToLower is unicode aware, but everything else we do is on bytes, not runes). I don't think its worth making it unicode aware yet.
* We could avoid allocating memory for queryLower and targetLower. However, we would then miss out on the nicely optimized `strings.IndexByte` implementation. So unlikely worth the tradeoff.