### PR TITLE
Minor cleanup to match Go style + Unicode support

### DIFF
--- a/stringscore.go
+++ b/stringscore.go
@@ -25,13 +25,15 @@ func Score(target string, query string) int {
 		return 0 // impossible for query to be a substring
 	}
 
-	targetLower := strings.ToLower(target)
-	queryLower := strings.ToLower(query)
+	targetRunes := []rune(target)
+	queryRunes := []rune(query)
+	targetLower := []rune(strings.ToLower(target))
+	queryLower := []rune(strings.ToLower(query))
 
 	score := 0
 
-	for queryIdx := 0; queryIdx < len(query); queryIdx++ {
-		targetIdx := strings.IndexByte(targetLower, queryLower[queryIdx])
+	for queryIdx := 0; queryIdx < len(queryRunes); queryIdx++ {
+		targetIdx := runeIndex(targetLower, queryLower[queryIdx])
 		if targetIdx == -1 {
 			score = 0 // This makes sure that the query is contained in the target
 			break
@@ -46,31 +48,39 @@ func Score(target string, query string) int {
 		}
 
 		// Same case bonus
-		if target[targetIdx] == query[queryIdx] {
+		if targetRunes[targetIdx] == queryRunes[queryIdx] {
 			score++
 		}
 
 		// Start of word bonus
 		if targetIdx == 0 {
 			score += 8
-		} else if isWordSeparator(target[targetIdx-1]) {
+		} else if isWordSeparator(targetRunes[targetIdx-1]) {
 			// After separator bonus
 			score += 7
-		} else if unicode.IsUpper(rune(target[targetIdx])) {
+		} else if unicode.IsUpper(targetRunes[targetIdx]) {
 			// Inside word upper case bonus
 			score++
 		}
 
-		// Remove one character from the start of target strings.
+		// Remove one rune from the start of target strings.
 		targetLower = targetLower[1:]
-		target = target[1:]
+		targetRunes = targetRunes[1:]
 	}
-
 	return score
 }
 
 const wordPathBoundary = "-_ /\\."
 
-func isWordSeparator(c byte) bool {
-	return strings.IndexByte(wordPathBoundary, c) >= 0
+func isWordSeparator(r rune) bool {
+	return strings.IndexRune(wordPathBoundary, r) >= 0
+}
+
+func runeIndex(s []rune, r rune) int {
+	for i, s := range s {
+		if s == r {
+			return i
+		}
+	}
+	return -1
 }

--- a/stringscore.go
+++ b/stringscore.go
@@ -32,12 +32,12 @@ func Score(target string, query string) int {
 	score := 0
 
 	for queryIdx := 0; queryIdx < len(query); queryIdx++ {
-		targetIdx := strings.IndexByte(targetLower[startAt:], queryLower[queryIdx]) + startAt
-
-		if targetIdx < startAt {
+		targetIdx := strings.IndexByte(targetLower[startAt:], queryLower[queryIdx])
+		if targetIdx == -1 {
 			score = 0 // This makes sure that the query is contained in the target
 			break
 		}
+		targetIdx += startAt
 
 		// Character match bonus
 		score++

--- a/stringscore.go
+++ b/stringscore.go
@@ -28,22 +28,20 @@ func Score(target string, query string) int {
 	targetLower := strings.ToLower(target)
 	queryLower := strings.ToLower(query)
 
-	startAt := 0
 	score := 0
 
 	for queryIdx := 0; queryIdx < len(query); queryIdx++ {
-		targetIdx := strings.IndexByte(targetLower[startAt:], queryLower[queryIdx])
+		targetIdx := strings.IndexByte(targetLower, queryLower[queryIdx])
 		if targetIdx == -1 {
 			score = 0 // This makes sure that the query is contained in the target
 			break
 		}
-		targetIdx += startAt
 
 		// Character match bonus
 		score++
 
 		// Consecutive match bonus
-		if startAt == targetIdx {
+		if targetIdx == 0 {
 			score += 5
 		}
 
@@ -63,7 +61,9 @@ func Score(target string, query string) int {
 			score++
 		}
 
-		startAt = targetIdx + 1
+		// Remove one character from the start of target strings.
+		targetLower = targetLower[1:]
+		target = target[1:]
 	}
 
 	return score

--- a/stringscore.go
+++ b/stringscore.go
@@ -4,6 +4,7 @@ package stringscore
 
 import (
 	"strings"
+	"unicode"
 )
 
 // Score computes a score for the given string and the given query.
@@ -16,7 +17,6 @@ import (
 // Start of word/path bonus: 7
 // Start of string bonus: 8
 func Score(target string, query string) int {
-
 	if target == "" || query == "" {
 		return 0 // return early if target or query are undefined
 	}
@@ -58,7 +58,7 @@ func Score(target string, query string) int {
 		} else if isWordSeparator(target[targetIdx-1]) {
 			// After separator bonus
 			score += 7
-		} else if isUpperASCII(target[targetIdx]) {
+		} else if unicode.IsUpper(rune(target[targetIdx])) {
 			// Inside word upper case bonus
 			score++
 		}
@@ -73,8 +73,4 @@ const wordPathBoundary = "-_ /\\."
 
 func isWordSeparator(c byte) bool {
 	return strings.IndexByte(wordPathBoundary, c) >= 0
-}
-
-func isUpperASCII(c byte) bool {
-	return 65 <= c && c <= 90
 }

--- a/stringscore_test.go
+++ b/stringscore_test.go
@@ -10,20 +10,21 @@ import (
 func TestScore(t *testing.T) {
 	target := "HeLlo-World"
 
-	scores := make([]int, 0, 0)
-	scores = append(scores, stringscore.Score(target, "HelLo-World")) // direct case match
-	scores = append(scores, stringscore.Score(target, "hello-world")) // direct mix-case match
-	scores = append(scores, stringscore.Score(target, "HW"))          // direct case prefix (multiple)
-	scores = append(scores, stringscore.Score(target, "hw"))          // direct mix-case prefix (multiple)
-	scores = append(scores, stringscore.Score(target, "H"))           // direct case prefix
-	scores = append(scores, stringscore.Score(target, "h"))           // direct mix-case prefix
-	scores = append(scores, stringscore.Score(target, "W"))           // direct case word prefix
-	scores = append(scores, stringscore.Score(target, "w"))           // direct mix-case word prefix
-	scores = append(scores, stringscore.Score(target, "Ld"))          // in-string case match (multiple)
-	scores = append(scores, stringscore.Score(target, "ld"))          // in-string mix-case match
-	scores = append(scores, stringscore.Score(target, "L"))           // in-string case match
-	scores = append(scores, stringscore.Score(target, "l"))           // in-string mix-case match
-	scores = append(scores, stringscore.Score(target, "4"))           // no match
+	scores := []int{
+		stringscore.Score(target, "HelLo-World"), // direct case match
+		stringscore.Score(target, "hello-world"), // direct mix-case match
+		stringscore.Score(target, "HW"),          // direct case prefix (multiple)
+		stringscore.Score(target, "hw"),          // direct mix-case prefix (multiple)
+		stringscore.Score(target, "H"),           // direct case prefix
+		stringscore.Score(target, "h"),           // direct mix-case prefix
+		stringscore.Score(target, "W"),           // direct case word prefix
+		stringscore.Score(target, "w"),           // direct mix-case word prefix
+		stringscore.Score(target, "Ld"),          // in-string case match (multiple)
+		stringscore.Score(target, "ld"),          // in-string mix-case match
+		stringscore.Score(target, "L"),           // in-string case match
+		stringscore.Score(target, "l"),           // in-string mix-case match
+		stringscore.Score(target, "4"),           // no match
+	}
 
 	// Assert scoring order
 	sortedScores := make([]int, len(scores))

--- a/stringscore_test.go
+++ b/stringscore_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestScore(t *testing.T) {
-	target := "HeLlo-World"
+	target := "H❄Ll❄-World"
 
 	scores := []int{
-		stringscore.Score(target, "HelLo-World"), // direct case match
-		stringscore.Score(target, "hello-world"), // direct mix-case match
+		stringscore.Score(target, "H❄lL❄-World"), // direct case match
+		stringscore.Score(target, "h❄ll❄-world"), // direct mix-case match
 		stringscore.Score(target, "HW"),          // direct case prefix (multiple)
 		stringscore.Score(target, "hw"),          // direct mix-case prefix (multiple)
 		stringscore.Score(target, "H"),           // direct case prefix


### PR DESCRIPTION
Best reviewed as individual commits:

- Switch to using array literal syntax (I noticed you needlessly used `append` and `make`).
- Use `unicode.IsUpper` instead of defining a custom `isUpperASCII` function.
- Replace `startAt` with just string slicing operations, since the algorithm supports it and it is more canonical to do this in Go.
- Operate on runes (`[]rune(theString)`) instead of bytes to support correct scoring of Unicode strings.

