### PR TITLE
fix failing test for preferring exact over fuzzy matches

### DIFF
--- a/stringscore.go
+++ b/stringscore.go
@@ -64,8 +64,8 @@ func Score(target string, query string) int {
 		}
 
 		// Remove one rune from the start of target strings.
-		targetLower = targetLower[1:]
-		targetRunes = targetRunes[1:]
+		targetLower = targetLower[targetIdx+1:]
+		targetRunes = targetRunes[targetIdx+1:]
 	}
 	return score
 }

--- a/stringscore_test.go
+++ b/stringscore_test.go
@@ -41,6 +41,15 @@ func TestScore(t *testing.T) {
 	}
 }
 
+func TestExactMatchIsPrefferedOverFuzzyMatch(t *testing.T) {
+	query := "backend"
+	fuzzyScore := stringscore.Score("vendor/github.com/coreos/go-oidc/key/manager.go", query)
+	exactScore := stringscore.Score("pkg/backend/trace.go", query)
+	if fuzzyScore >= exactScore {
+		t.Errorf("Expected a fuzzy match to have a lower score than an exact match, fuzzy: %v, exact: %v", fuzzyScore, exactScore)
+	}
+}
+
 func TestZeroScoreOnEmptyTarget(t *testing.T) {
 	score := stringscore.Score("", "foo")
 	if score != 0 {


### PR DESCRIPTION
Includes / replaces https://github.com/felixfbecker/stringscore/pull/3

In 0d40829 / #2 I incorrectly rewrote the code to slice off the first character of the string, but the reality was that it was actually slicing off `targetIdx + 1`. For example the old code:

```Go
targetIdx := strings.IndexByte(targetLower[startAt:], queryLower[queryIdx])
...
startAt = targetIdx + 1
```

was incorrectly translated into:

```Go
targetIdx := strings.IndexByte(targetLower, queryLower[queryIdx])
...
targetLower = targetLower[1:]
```

When it should have been translated into:

```Go
targetIdx := strings.IndexByte(targetLower, queryLower[queryIdx])
...
targetLower = targetLower[targetIdx+1:]
```

I didn't catch this (sorry 😞 ), but Felix did and the new test he added proves it. :)