### PR TITLE
Performance Optimisations

### DIFF
--- a/stringscore.go
+++ b/stringscore.go
@@ -26,13 +26,12 @@ func Score(target string, query string) int {
 	}
 
 	targetRunes := []rune(target)
-	targetLower := []rune(strings.ToLower(target))
 
 	startAt := 0
 	score := 0
 
 	for _, queryC := range query {
-		targetIdx := runeIndex(targetLower[startAt:], unicode.ToLower(queryC)) + startAt
+		targetIdx := runeIndexLower(targetRunes[startAt:], unicode.ToLower(queryC)) + startAt
 
 		if targetIdx < startAt {
 			score = 0 // This makes sure that the query is contained in the target
@@ -74,9 +73,9 @@ func isWordSeparator(r rune) bool {
 	return strings.IndexRune(wordPathBoundary, r) >= 0
 }
 
-func runeIndex(s []rune, r rune) int {
+func runeIndexLower(s []rune, r rune) int {
 	for i, s := range s {
-		if s == r {
+		if unicode.ToLower(s) == r {
 			return i
 		}
 	}

--- a/stringscore.go
+++ b/stringscore.go
@@ -26,15 +26,13 @@ func Score(target string, query string) int {
 	}
 
 	targetRunes := []rune(target)
-	queryRunes := []rune(query)
 	targetLower := []rune(strings.ToLower(target))
-	queryLower := []rune(strings.ToLower(query))
 
 	startAt := 0
 	score := 0
 
-	for queryIdx := 0; queryIdx < len(queryRunes); queryIdx++ {
-		targetIdx := runeIndex(targetLower[startAt:], queryLower[queryIdx]) + startAt
+	for _, queryC := range query {
+		targetIdx := runeIndex(targetLower[startAt:], unicode.ToLower(queryC)) + startAt
 
 		if targetIdx < startAt {
 			score = 0 // This makes sure that the query is contained in the target
@@ -50,7 +48,7 @@ func Score(target string, query string) int {
 		}
 
 		// Same case bonus
-		if targetRunes[targetIdx] == queryRunes[queryIdx] {
+		if targetRunes[targetIdx] == queryC {
 			score++
 		}
 

--- a/stringscore.go
+++ b/stringscore.go
@@ -30,11 +30,13 @@ func Score(target string, query string) int {
 	targetLower := []rune(strings.ToLower(target))
 	queryLower := []rune(strings.ToLower(query))
 
+	startAt := 0
 	score := 0
 
 	for queryIdx := 0; queryIdx < len(queryRunes); queryIdx++ {
-		targetIdx := runeIndex(targetLower, queryLower[queryIdx])
-		if targetIdx == -1 {
+		targetIdx := runeIndex(targetLower[startAt:], queryLower[queryIdx]) + startAt
+
+		if targetIdx < startAt {
 			score = 0 // This makes sure that the query is contained in the target
 			break
 		}
@@ -43,7 +45,7 @@ func Score(target string, query string) int {
 		score++
 
 		// Consecutive match bonus
-		if targetIdx == 0 {
+		if targetIdx == startAt {
 			score += 5
 		}
 
@@ -63,9 +65,7 @@ func Score(target string, query string) int {
 			score++
 		}
 
-		// Remove one rune from the start of target strings.
-		targetLower = targetLower[targetIdx+1:]
-		targetRunes = targetRunes[targetIdx+1:]
+		startAt = targetIdx + 1
 	}
 	return score
 }

--- a/stringscore_test.go
+++ b/stringscore_test.go
@@ -70,3 +70,14 @@ func TestZeroScoreOnQueryLongerThanTarget(t *testing.T) {
 		t.Errorf("Expected query longer than target to result in score of zero, got: %v", score)
 	}
 }
+
+func BenchmarkScoreASCII(b *testing.B) {
+	query := "backend"
+	target := "vendor/github.com/gorilla/websocket/conn_read_legacy.go"
+	for n := 0; n <= b.N; n++ {
+		score := stringscore.Score(target, query)
+		if score <= 0 {
+			b.Fatal("Expected a match")
+		}
+	}
+}

--- a/stringscore_test.go
+++ b/stringscore_test.go
@@ -43,7 +43,7 @@ func TestScore(t *testing.T) {
 
 func TestExactMatchIsPrefferedOverFuzzyMatch(t *testing.T) {
 	query := "backend"
-	fuzzyScore := stringscore.Score("vendor/github.com/coreos/go-oidc/key/manager.go", query)
+	fuzzyScore := stringscore.Score("vendor/github.com/gorilla/websocket/conn_read_legacy.go", query)
 	exactScore := stringscore.Score("pkg/backend/trace.go", query)
 	if fuzzyScore >= exactScore {
 		t.Errorf("Expected a fuzzy match to have a lower score than an exact match, fuzzy: %v, exact: %v", fuzzyScore, exactScore)


### PR DESCRIPTION
This increases the performance of `Scorer` via reducing the number of allocations it does to none. Also included is a fix for a regression introduced in #2 where the start of word bonus was awarded for consecutive matches as well.

```
$ go test -run '^$' -bench '.*' -benchmem
Before
BenchmarkScoreASCII-4            2000000               757 ns/op             448 B/op          2 allocs/op

After
BenchmarkScoreASCII-4            3000000               450 ns/op               0 B/op          0 allocs/op
```